### PR TITLE
Remove all explicit new-style class `object`

### DIFF
--- a/quart/ctx.py
+++ b/quart/ctx.py
@@ -360,7 +360,7 @@ def has_websocket_context() -> bool:
 _sentinel = object()
 
 
-class _AppCtxGlobals(object):
+class _AppCtxGlobals:
     """The g class, a plain object with some mapping methods."""
 
     def get(self, name: str, default: Optional[Any]=None) -> Any:

--- a/quart/datastructures.py
+++ b/quart/datastructures.py
@@ -38,7 +38,7 @@ class CIMultiDict(_WerkzeugMultidictMixin, AIOCIMultiDict):  # type: ignore
     pass
 
 
-class FileStorage(object):
+class FileStorage:
     """A thin wrapper over incoming files."""
 
     def __init__(


### PR DESCRIPTION
> Python 3.6.1 is the minimum required version

all classes are new style in py3