### PR TITLE
use ipython when shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/reference/source/
 dist/
 .coverage
 poetry.lock
+.idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ quart = "quart.cli:main"
 
 [tool.poetry.extras]
 dotenv = ["python-dotenv"]
+ipython = ["ipython"]
 
 [tool.black]
 line-length = 100

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import code
 import os
-import sys
 from unittest.mock import Mock
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     pytest-asyncio
     pytest-cov
     pytest-sugar
+    ipython
 commands = pytest --cov=quart {posargs}
 
 [testenv:docs]
@@ -64,6 +65,7 @@ deps =
     pytest-sugar
     types-aiofiles
     python-dotenv
+    ipython
 commands =
     mypy src/quart/ tests/
 


### PR DESCRIPTION
```
Name                                                                      Stmts   Miss  Cover
---------------------------------------------------------------------------------------------
.tox/py38/lib/python3.8/site-packages/quart/__init__.py                      16      0   100%
.tox/py38/lib/python3.8/site-packages/quart/__main__.py                       4      4     0%
.tox/py38/lib/python3.8/site-packages/quart/app.py                          675    146    78%
.tox/py38/lib/python3.8/site-packages/quart/asgi.py                         177     27    85%
.tox/py38/lib/python3.8/site-packages/quart/blueprints.py                   198     39    80%
.tox/py38/lib/python3.8/site-packages/quart/cli.py                          209     77    63%
.tox/py38/lib/python3.8/site-packages/quart/config.py                        97      9    91%
.tox/py38/lib/python3.8/site-packages/quart/ctx.py                          212     24    89%
.tox/py38/lib/python3.8/site-packages/quart/datastructures.py                23     12    48%
.tox/py38/lib/python3.8/site-packages/quart/debug.py                         21      2    90%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/__init__.py          26     26     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/_patch.py            79     79     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/_synchronise.py      18     18     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/app.py               37     37     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/cli.py                3      3     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/globals.py           29     29     0%
.tox/py38/lib/python3.8/site-packages/quart/flask_patch/testing.py            4      4     0%
.tox/py38/lib/python3.8/site-packages/quart/formparser.py                    95     57    40%
.tox/py38/lib/python3.8/site-packages/quart/globals.py                       29      5    83%
.tox/py38/lib/python3.8/site-packages/quart/helpers.py                      183     26    86%
.tox/py38/lib/python3.8/site-packages/quart/json/__init__.py                 82     21    74%
.tox/py38/lib/python3.8/site-packages/quart/json/tag.py                     120     14    88%
.tox/py38/lib/python3.8/site-packages/quart/logging.py                       35      7    80%
.tox/py38/lib/python3.8/site-packages/quart/routing.py                       36      2    94%
.tox/py38/lib/python3.8/site-packages/quart/scaffold.py                     209     42    80%
.tox/py38/lib/python3.8/site-packages/quart/sessions.py                     139     13    91%
.tox/py38/lib/python3.8/site-packages/quart/signals.py                       49      0   100%
.tox/py38/lib/python3.8/site-packages/quart/templating.py                    59     22    63%
.tox/py38/lib/python3.8/site-packages/quart/testing/__init__.py              21      1    95%
.tox/py38/lib/python3.8/site-packages/quart/testing/app.py                   51      8    84%
.tox/py38/lib/python3.8/site-packages/quart/testing/client.py               145     19    87%
.tox/py38/lib/python3.8/site-packages/quart/testing/connections.py          129     15    88%
.tox/py38/lib/python3.8/site-packages/quart/testing/utils.py                 89      7    92%
.tox/py38/lib/python3.8/site-packages/quart/typing.py                       145     53    63%
.tox/py38/lib/python3.8/site-packages/quart/utils.py                         68     17    75%
.tox/py38/lib/python3.8/site-packages/quart/views.py                         44      2    95%
.tox/py38/lib/python3.8/site-packages/quart/wrappers/__init__.py              6      0   100%
.tox/py38/lib/python3.8/site-packages/quart/wrappers/base.py                 43      2    95%
.tox/py38/lib/python3.8/site-packages/quart/wrappers/request.py             159     27    83%
.tox/py38/lib/python3.8/site-packages/quart/wrappers/response.py            244     40    84%
.tox/py38/lib/python3.8/site-packages/quart/wrappers/websocket.py            38      3    92%
---------------------------------------------------------------------------------------------
TOTAL                                                                      4046    939    77%


Results (4.87s):
     259 passed
______________________________________________ summary _______________________________________________
  py38: commands succeeded
  congratulations :)

```