### PR TITLE
Correct url rule in cheatsheet documentation

### DIFF
--- a/docs/reference/cheatsheet.rst
+++ b/docs/reference/cheatsheet.rst
@@ -24,7 +24,7 @@ Routing
 
 .. code-block:: python
 
-    @app.route("/hello/<string: name>")  # example.com/hello/quart
+    @app.route("/hello/<string:name>")  # example.com/hello/quart
     async def hello(name):
         return f"Hello, {name}!"
 


### PR DESCRIPTION
the space after the `:` seems invalid:
```
  File "/xxx/venv39/lib/python3.9/site-packages/quart/app.py", line 510, in register_blueprint
    blueprint.register(self, options)
  File "/xxx/venv39/lib/python3.9/site-packages/quart/blueprints.py", line 584, in register
    func(state)
  File "/xxx/venv39/lib/python3.9/site-packages/quart/blueprints.py", line 113, in <lambda>
    lambda state: state.add_url_rule(
  File "/xxx/venv39/lib/python3.9/site-packages/quart/blueprints.py", line 681, in add_url_rule
    self.app.add_url_rule(
  File "/xxx/venv39/lib/python3.9/site-packages/quart/app.py", line 602, in add_url_rule
    self.url_map.add(rule)
  File "/xxx/venv39/lib/python3.9/site-packages/werkzeug/routing.py", line 1546, in add
    rule.bind(self)
  File "/xxx/venv39/lib/python3.9/site-packages/werkzeug/routing.py", line 805, in bind
    self.compile()
  File "/xxx/venv39/lib/python3.9/site-packages/werkzeug/routing.py", line 880, in compile
    _build_regex(self.rule if self.is_leaf else self.rule.rstrip("/"))
  File "/xxx/venv39/lib/python3.9/site-packages/werkzeug/routing.py", line 847, in _build_regex
    for converter, arguments, variable in parse_rule(rule):
  File "/xxx/venv39/lib/python3.9/site-packages/werkzeug/routing.py", line 243, in parse_rule
    raise ValueError(f"malformed url rule: {rule!r}")
ValueError: malformed url rule: '/hello/<string: name>'
```
It took me some time to figure this was the issue :smile: 